### PR TITLE
Fix: enable 'inlineSources' on tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,7 @@
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    "inlineSources": true,                               /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
     // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */


### PR DESCRIPTION
## Issue 

If we use this library, following error occur.
The reason is that the source map don't have the field `sourcesContent` and the file which is mentioned in `sources` field.

```
WARNING in ./node_modules/http-status-ts/esm/HttpMethod.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/home/aaa/project-name/node_modules/src/HttpMethod.ts' file: Error: ENOENT: no such file or directory, open '/home/aaa/project-name/node_modules/src/HttpMethod.ts'
```

## Modification
This PR enable `inlineSources` option and update to include `sourcesContent` in output source maps.

ie) build/cjs/HttpMethod.js.map

AS-IS
```
{"version":3,"file":"HttpMethod.js","sourceRoot":"","sources":["../../src/HttpMethod.ts"],"names":[],"mappings":";;;AAAA,IAAY,UASX;AATD,WAAY,UAAU;IAClB,yBAAW,CAAA;IACX,2BAAa,CAAA;IACb,yBAAW,CAAA;IACX,+BAAiB,CAAA;IACjB,iCAAmB,CAAA;IACnB,iCAAmB,CAAA;IACnB,6BAAe,CAAA;IACf,6BAAe,CAAA;AACnB,CAAC,EATW,UAAU,0BAAV,UAAU,QASrB"}
```

TO-BE
```
{"version":3,"file":"HttpMethod.js","sourceRoot":"","sources":["../../src/HttpMethod.ts"],"names":[],"mappings":";;;AAAA,IAAY,UASX;AATD,WAAY,UAAU;IAClB,yBAAW,CAAA;IACX,2BAAa,CAAA;IACb,yBAAW,CAAA;IACX,+BAAiB,CAAA;IACjB,iCAAmB,CAAA;IACnB,iCAAmB,CAAA;IACnB,6BAAe,CAAA;IACf,6BAAe,CAAA;AACnB,CAAC,EATW,UAAU,0BAAV,UAAU,QASrB","sourcesContent":["export enum HttpMethod {\r\n    GET = \"GET\",\r\n    POST = \"POST\",\r\n    PUT = \"PUT\",\r\n    DELETE = \"DELETE\",\r\n    CONNECT = \"CONNECT\",\r\n    OPTIONS = \"OPTIONS\",\r\n    TRACE = \"TRACE\",\r\n    PATCH = \"PATCH\"\r\n}\r\n"]}
```